### PR TITLE
Ulid validator re

### DIFF
--- a/patterns.go
+++ b/patterns.go
@@ -12,6 +12,7 @@ const (
 	UUID4             string = "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
 	UUID5             string = "^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
 	UUID              string = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+	ULID              string = "(?i)^[0-7]{1}[0-9a-hjkm-np-tv-z]{25}$"
 	Alpha             string = "^[a-zA-Z]+$"
 	Alphanumeric      string = "^[a-zA-Z0-9]+$"
 	Numeric           string = "^[0-9]+$"
@@ -74,6 +75,7 @@ var (
 	rxUUID4             = regexp.MustCompile(UUID4)
 	rxUUID5             = regexp.MustCompile(UUID5)
 	rxUUID              = regexp.MustCompile(UUID)
+	rxULID              = regexp.MustCompile(ULID)
 	rxAlpha             = regexp.MustCompile(Alpha)
 	rxAlphanumeric      = regexp.MustCompile(Alphanumeric)
 	rxNumeric           = regexp.MustCompile(Numeric)

--- a/validator.go
+++ b/validator.go
@@ -361,6 +361,11 @@ func IsUUID(str string) bool {
 	return rxUUID.MatchString(str)
 }
 
+// IsULID checks if the string is a ULID.
+func IsULID_RE(str string) bool {
+	return rxULID.MatchString(str)
+}
+
 // Byte to index table for O(1) lookups when unmarshaling.
 // We use 0xFF as sentinel value for invalid indexes.
 var ulidDec = [...]byte{

--- a/validator_test.go
+++ b/validator_test.go
@@ -1460,6 +1460,52 @@ func TestIsULID(t *testing.T) {
 	}
 }
 
+func BenchmarkIsULID_RE(b *testing.B) {
+	var ulids []string = []string{
+		"0000000000zzzzzzzzzzzzzzzz", // true
+		"0123456789zzzzzzzzzzzzzzzz", // true
+		"0123456789abcdefghjkmnpqrs", // true
+		"7zzzzzzzzzaaaaaaaaaaaaaaaa", // true
+		"7zanmkqfpyaaaaaaaaaaaaaaaa", // true
+		"7zanmkqfpyaaaaaaaaaaAAAAAA", // true
+		"8000000000zzzzzzzzzzzzzzzz", // false
+		"8000000001zzzzzzzzzzzzzzzz", // false
+		"8123456789zzzzzzzzzzzzzzzz", // false
+		"8123456789zzzzzzzzzzzzzzzL", // false
+		"8123456789zzzzzzzzzzzzzzzO", // false
+		"8123456789zzzzzzzzzzzzzzzu", // false
+		"8123456789zzzzzzzzzzzzzzzI", // false
+	}
+
+	b.SetBytes(int64(len(ulids[0])))
+	for i := 0; i < b.N; i++ {
+		_ = IsULID_RE(ulids[i%len(ulids)])
+	}
+}
+
+func BenchmarkIsULID(b *testing.B) {
+	var ulids []string = []string{
+		"0000000000zzzzzzzzzzzzzzzz", // true
+		"0123456789zzzzzzzzzzzzzzzz", // true
+		"0123456789abcdefghjkmnpqrs", // true
+		"7zzzzzzzzzaaaaaaaaaaaaaaaa", // true
+		"7zanmkqfpyaaaaaaaaaaaaaaaa", // true
+		"7zanmkqfpyaaaaaaaaaaAAAAAA", // true
+		"8000000000zzzzzzzzzzzzzzzz", // false
+		"8000000001zzzzzzzzzzzzzzzz", // false
+		"8123456789zzzzzzzzzzzzzzzz", // false
+		"8123456789zzzzzzzzzzzzzzzL", // false
+		"8123456789zzzzzzzzzzzzzzzO", // false
+		"8123456789zzzzzzzzzzzzzzzu", // false
+		"8123456789zzzzzzzzzzzzzzzI", // false
+	}
+
+	b.SetBytes(int64(len(ulids[0])))
+	for i := 0; i < b.N; i++ {
+		_ = IsULID(ulids[i%len(ulids)])
+	}
+}
+
 func TestIsCreditCard(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
Benchmark Regexp and Index array driven ULID validation:

```sh
go test -bench BenchmarkIsULID -benchmem
pkg: github.com/asaskevich/govalidator
BenchmarkIsULID_RE-4   	 4085954	       281 ns/op	  92.41 MB/s	       0 B/op	       0 allocs/op
BenchmarkIsULID-4      	60308574	        17.5 ns/op	1482.27 MB/s	       0 B/op	       0 allocs/op
PASS
ok  	github.com/asaskevich/govalidator	2.880s
```